### PR TITLE
Enable printing command lines

### DIFF
--- a/macros.cargo
+++ b/macros.cargo
@@ -1,7 +1,7 @@
 
 %__rustflags -Clink-arg=-Wl,-z,relro,-z,now -C debuginfo=2 -C incremental=false
 %__cargo CARGO_FEATURE_VENDORED=1 RUSTFLAGS="%{__rustflags}" %{_bindir}/cargo
-%__cargo_common_opts %{?_smp_mflags}
+%__cargo_common_opts %{?_smp_mflags} -v
 
 %rust_arches x86_64 i586 i686 armv6hl armv7hl aarch64 ppc64 powerpc64 ppc64le powerpc64le riscv64 s390x
 %rust_tier1_arches x86_64 aarch64


### PR DESCRIPTION
openSUSE is using --disable-silent-rules in many packages; apply the same for cargo, but on a global scale.