### PR TITLE
marcos.cargo: drop path from install

### DIFF
--- a/macros.cargo
+++ b/macros.cargo
@@ -27,7 +27,7 @@
     %* \
 }
 
-%cargo_install() \
+%cargo_install(p:) \
 %{shrink:\
     unset LIBSSH2_SYS_USE_PKG_CONFIG && \
     if [[ -z $RUSTC_WRAPPER ]]; then CARGO_AUDITABLE="auditable" ; fi && \
@@ -36,7 +36,6 @@
     --offline \
     --no-track \
     --root=%{buildroot}%{_prefix} \
-    --path . \
+    --path %{-p:%{-p*}}%{!-p:.} \
     %* \
 }
-


### PR DESCRIPTION
The `%{cargo_install}` macro is expanded adding a `--path .` paramenter
at the end.  With virtual workspaces we need to specify a different
`path` per binary crate, but this cannot be done if there is already one
`path` parameter.

This patch adds a path parameter (-p) in the cargo_install macro, that
if it is not present will default to the current "--path ." one.  Now an
user can specify a different path parameter:

  %{cargo_install -p binary-crate} --no-default-features

Related with:

  https://github.com/rust-lang/cargo/issues/7599

Signed-off-by: Alberto Planas <aplanas@suse.com>