### PR TITLE
Drop bashisms from macros.cargo file

### DIFF
--- a/macros.cargo
+++ b/macros.cargo
@@ -10,7 +10,7 @@
 %cargo_build() \
 %{shrink:\
     unset LIBSSH2_SYS_USE_PKG_CONFIG && \
-    if [[ -z $RUSTC_WRAPPER ]]; then CARGO_AUDITABLE="auditable" ; fi && \
+    if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE build \
     %{__cargo_common_opts} \
     --offline --release \
@@ -20,7 +20,7 @@
 %cargo_test() \
 %{shrink:\
     unset LIBSSH2_SYS_USE_PKG_CONFIG && \
-    if [[ -z $RUSTC_WRAPPER ]]; then CARGO_AUDITABLE="auditable" ; fi && \
+    if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE test \
     %{__cargo_common_opts} \
     --offline \
@@ -31,7 +31,7 @@
 %cargo_install(p:) \
 %{shrink:\
     unset LIBSSH2_SYS_USE_PKG_CONFIG && \
-    if [[ -z $RUSTC_WRAPPER ]]; then CARGO_AUDITABLE="auditable" ; fi && \
+    if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE install \
     %{__cargo_common_opts} \
     --offline \


### PR DESCRIPTION
**openSUSE**/**SUSE**'s default build environment doesn't set `%_buildshell`. That means the value of such macro is the original `/bin/sh`, set by **RPM**'s /usr/lib/rpm/macros file. So we should avoid bashisms, like [[ ... ]], without explicitly setting the `%_buildshell` macro to `/bin/bash`.