### PR TITLE
Install should take --release

### DIFF
--- a/macros.cargo
+++ b/macros.cargo
@@ -1,7 +1,7 @@
 
 
 %build_rustflags -Clink-arg=-Wl,-z,relro,-z,now -C debuginfo=2 -C strip=none
-%__cargo CARGO_INCREMENTAL=0 CARGO_FEATURE_VENDORED=1 RUSTFLAGS="%{?__rustflags} %{?build_rustflags}" CARGO_TARGET_DIR=%{_builddir}/%{name}-%{version}/target/ %{_bindir}/cargo
+%__cargo CARGO_INCREMENTAL=0 CARGO_FEATURE_VENDORED=1 RUSTFLAGS="%{?__rustflags} %{?build_rustflags}" CARGO_TARGET_DIR=%{_builddir}/%{buildsubdir}/target/ %{_bindir}/cargo
 %__cargo_common_opts %{?_smp_mflags}
 
 %rust_arches x86_64 i586 i686 armv6hl armv7hl aarch64 ppc64 powerpc64 ppc64le powerpc64le riscv64 s390x

--- a/macros.cargo
+++ b/macros.cargo
@@ -1,7 +1,7 @@
 
 
 %build_rustflags -Clink-arg=-Wl,-z,relro,-z,now -C debuginfo=2 -C strip=none
-%__cargo CARGO_INCREMENTAL=0 CARGO_FEATURE_VENDORED=1 RUSTFLAGS="%{?__rustflags} %{?build_rustflags}" %{_bindir}/cargo
+%__cargo CARGO_INCREMENTAL=0 CARGO_FEATURE_VENDORED=1 RUSTFLAGS="%{?__rustflags} %{?build_rustflags}" CARGO_TARGET_DIR=%{_builddir}/%{name}-%{version}/target/ %{_bindir}/cargo
 %__cargo_common_opts %{?_smp_mflags}
 
 %rust_arches x86_64 i586 i686 armv6hl armv7hl aarch64 ppc64 powerpc64 ppc64le powerpc64le riscv64 s390x
@@ -13,7 +13,7 @@
     if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE build \
     %{__cargo_common_opts} \
-    --offline --release \
+    --offline --locked --release \
     %* \
 }
 
@@ -23,7 +23,7 @@
     if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE test \
     %{__cargo_common_opts} \
-    --offline \
+    --offline --locked \
     --no-fail-fast \
     %* \
 }
@@ -34,7 +34,7 @@
     if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE install \
     %{__cargo_common_opts} \
-    --offline \
+    --offline --locked \
     --no-track \
     --root=%{buildroot}%{_prefix} \
     --path %{-p:%{-p*}}%{!-p:.} \


### PR DESCRIPTION
    Correct cargo flags to prevent install rebuild

    To prevent install rebuilding we needed to specify the CARGO_TARGET_DIR
    manually due to rust [issue #4725](https://github.com/rust-lang/cargo/issues/4725#issuecomment-352967892)

    In addition, even once this is inplace, we must pass --locked to prevent
    any attempt to update the package dependencies such as git repo
    dependencies.