### PR TITLE
Always Run Cargo In Release Mode

### DIFF
--- a/macros.cargo
+++ b/macros.cargo
@@ -2,7 +2,7 @@
 
 %build_rustflags -Clink-arg=-Wl,-z,relro,-z,now -C debuginfo=2 -C strip=none
 %__cargo CARGO_INCREMENTAL=0 CARGO_FEATURE_VENDORED=1 RUSTFLAGS="%{?__rustflags} %{?build_rustflags}" %{_bindir}/cargo
-%__cargo_common_opts %{?_smp_mflags}
+%__cargo_common_opts %{?_smp_mflags} --offline
 
 %rust_arches x86_64 i586 i686 armv6hl armv7hl aarch64 ppc64 powerpc64 ppc64le powerpc64le riscv64 s390x
 %rust_tier1_arches x86_64 aarch64
@@ -13,7 +13,7 @@
     if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE build \
     %{__cargo_common_opts} \
-    --offline --release \
+    --release \
     %* \
 }
 
@@ -23,8 +23,8 @@
     if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE test \
     %{__cargo_common_opts} \
-    --offline \
     --no-fail-fast \
+    --release \
     %* \
 }
 
@@ -34,7 +34,6 @@
     if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE install \
     %{__cargo_common_opts} \
-    --offline \
     --no-track \
     --root=%{buildroot}%{_prefix} \
     --path %{-p:%{-p*}}%{!-p:.} \


### PR DESCRIPTION
This commit changes the build flags of the cargo_test RPM macro, so Cargo runs in release mode. This way, the program doesn't get rebuilt between invocations of cargo. Release is the default target for the cargo install and listing it would result in an error.  Furthermore, it adds the option offline to the shared cargo flags, because it's a shared flag between the macros.

I use this change here <https://build.opensuse.org/package/show/home:janvhs/oniux> via this package <https://build.opensuse.org/package/show/home:janvhs:branches:devel:languages:rust/cargo-packaging>