### PR TITLE
Add missing --release flag on install step

### DIFF
--- a/macros.cargo
+++ b/macros.cargo
@@ -34,7 +34,7 @@
     if [ -z "$RUSTC_WRAPPER" ]; then CARGO_AUDITABLE="auditable" ; fi && \
     %{__cargo} $CARGO_AUDITABLE install \
     %{__cargo_common_opts} \
-    --offline --locked \
+    --offline --locked --release \
     --no-track \
     --root=%{buildroot}%{_prefix} \
     --path %{-p:%{-p*}}%{!-p:.} \


### PR DESCRIPTION
The release flag needs to be present on --install to prevent a rebuild 